### PR TITLE
Add handling for choice 0 when ask = TRUE

### DIFF
--- a/R/pretty_utils.R
+++ b/R/pretty_utils.R
@@ -166,7 +166,7 @@ pretty_find <- function(NMPATH, sos, sym.funs, funs, ask, askenv){
             
           }else{
           
-            menu_choices <- c(sprintf('%s(*)', choices), choices, "Ignore Instance", "Ignore All(*)")
+            menu_choices <- unique(c(sprintf('%s(*)', choices), choices, "Ignore Instance", "Ignore All(*)"))
             
             menu_title <- sprintf('Select which namespace to use for "%s"\n(*) if you want it to persist for all subsequent instances',fun)
             

--- a/R/pretty_utils.R
+++ b/R/pretty_utils.R
@@ -168,7 +168,7 @@ pretty_find <- function(NMPATH, sos, sym.funs, funs, ask, askenv){
           
             menu_choices <- c(sprintf('%s(*)', choices), choices, "Ignore Instance", "Ignore All(*)")
             
-            menu_title <- sprintf('Select which namespace to use for "%s"\n(*) if you want it to persist for all subsequent instances\n zero `0` will omit a namespace',fun)
+            menu_title <- sprintf('Select which namespace to use for "%s"\n(*) if you want it to persist for all subsequent instances',fun)
             
             choice_idx <- utils::menu(choices = menu_choices,title=menu_title)
             

--- a/R/pretty_utils.R
+++ b/R/pretty_utils.R
@@ -91,7 +91,7 @@ pretty_manip <- function(sym.funs, force, ignore){
     sym.funs <- pretty_merge(sym.funs,ignore,'remove')
   }
   
-    sym.funs$new_text <- sprintf('%s%s',ifelse(nchar(sym.funs$namespace) > 0, paste0(sym.funs$namespace,"::"), ''), sym.funs$text)
+    sym.funs$new_text <- sprintf('%s%s',ifelse(nzchar(sym.funs$namespace), paste0(sym.funs$namespace,"::"), ''), sym.funs$text)
   
   sym.funs
 }

--- a/R/pretty_utils.R
+++ b/R/pretty_utils.R
@@ -160,11 +160,15 @@ pretty_find <- function(NMPATH, sos, sym.funs, funs, ask, askenv){
           
           intersect_choices <- intersect(persistent_choices,choices)
           
-          if(length(intersect_choices)>0){
+          
+          
+          if(length(intersect_choices) > 0){
             
             choice <- intersect_choices
             
-          }else{
+          } else if (paste0("Ignore::", fun) %in% persistent_choices) {
+            choice <- ''
+          } else {
           
             menu_choices <- unique(c(sprintf('%s(*)', choices), choices, "Ignore Instance", "Ignore All(*)"))
             
@@ -172,14 +176,16 @@ pretty_find <- function(NMPATH, sos, sym.funs, funs, ask, askenv){
             
             choice_idx <- utils::menu(choices = menu_choices,title=menu_title)
             
-            
-            choice <- menu_choices[choice_idx]
-            
-            if(grepl('\\(*\\)$',choice)){
-              clean_choice <- gsub('\\(\\*\\)$','',choice)
-              assign(clean_choice,TRUE,askenv)
-            }
-            
+              choice <- menu_choices[choice_idx]
+              
+              if(grepl('\\(*\\)$',choice)){
+                clean_choice <- gsub('\\(\\*\\)$','',choice)
+                if (grepl("^Ignore\\sAll", choice)) {
+                  clean_choice <- paste0("Ignore::",fun)
+                }
+                assign(clean_choice,TRUE,askenv)
+              }
+              
           }
           if (grepl("^Ignore\\s", choice)) choice <- ''
           pkg_choice <- gsub(':(.*?)$','',choice)  

--- a/R/pretty_utils.R
+++ b/R/pretty_utils.R
@@ -166,24 +166,23 @@ pretty_find <- function(NMPATH, sos, sym.funs, funs, ask, askenv){
             
           }else{
           
-            menu_choices <- c(sprintf('%s(*)',choices),choices)
+            menu_choices <- c(sprintf('%s(*)', choices), choices, "Ignore Instance", "Ignore All(*)")
             
             menu_title <- sprintf('Select which namespace to use for "%s"\n(*) if you want it to persist for all subsequent instances\n zero `0` will omit a namespace',fun)
             
             choice_idx <- utils::menu(choices = menu_choices,title=menu_title)
             
-            if (choice_idx != 0) {
+            
             choice <- menu_choices[choice_idx]
             
             if(grepl('\\(*\\)$',choice)){
               clean_choice <- gsub('\\(\\*\\)$','',choice)
+              if (grepl("^Ignore\\s", clean_choice)) clean_choice <- ''
               assign(clean_choice,TRUE,askenv)
             }
-            } else {
-              choice <- ''
-            }  
+            
           }
-          
+          if (grepl("^Ignore\\s", choice)) choice <- ''
           pkg_choice <- gsub(':(.*?)$','',choice)  
           
         }else{

--- a/R/pretty_utils.R
+++ b/R/pretty_utils.R
@@ -177,7 +177,6 @@ pretty_find <- function(NMPATH, sos, sym.funs, funs, ask, askenv){
             
             if(grepl('\\(*\\)$',choice)){
               clean_choice <- gsub('\\(\\*\\)$','',choice)
-              if (grepl("^Ignore\\s", clean_choice)) clean_choice <- ''
               assign(clean_choice,TRUE,askenv)
             }
             

--- a/R/pretty_utils.R
+++ b/R/pretty_utils.R
@@ -91,7 +91,7 @@ pretty_manip <- function(sym.funs, force, ignore){
     sym.funs <- pretty_merge(sym.funs,ignore,'remove')
   }
   
-  sym.funs$new_text <- sprintf('%s::%s',sym.funs$namespace, sym.funs$text)  
+    sym.funs$new_text <- sprintf('%s%s',ifelse(nchar(sym.funs$namespace) > 0, paste0(sym.funs$namespace,"::"), ''), sym.funs$text)
   
   sym.funs
 }
@@ -168,17 +168,20 @@ pretty_find <- function(NMPATH, sos, sym.funs, funs, ask, askenv){
           
             menu_choices <- c(sprintf('%s(*)',choices),choices)
             
-            menu_title <- sprintf('Select which namespace to use for "%s"\n(*) if you want it to persist for all subsequent instances\none will omit a namespace',fun)
+            menu_title <- sprintf('Select which namespace to use for "%s"\n(*) if you want it to persist for all subsequent instances\n zero `0` will omit a namespace',fun)
             
             choice_idx <- utils::menu(choices = menu_choices,title=menu_title)
             
+            if (choice_idx != 0) {
             choice <- menu_choices[choice_idx]
             
             if(grepl('\\(*\\)$',choice)){
               clean_choice <- gsub('\\(\\*\\)$','',choice)
               assign(clean_choice,TRUE,askenv)
             }
-              
+            } else {
+              choice <- ''
+            }  
           }
           
           pkg_choice <- gsub(':(.*?)$','',choice)  


### PR DESCRIPTION
When choice 0  is selected from the menu, a zero length character vector `''` is substituted for the choice. 
`sym.funs$new_text` now uses `paste0` & `ifelse` to pass the character vector to `sprintf` when the sym.funs$namespace is a character vector with length > 0