### PR TITLE
Load installed.packages on package load

### DIFF
--- a/R/0_installed_packages.R
+++ b/R/0_installed_packages.R
@@ -1,4 +1,0 @@
-#' @title ip
-#' @description  List all user's packages on load for future reference in functions (since this is an expensive operation)
-#' @importFrom utils installed.packages
-ip <- installed.packages()

--- a/R/0_installed_packages.R
+++ b/R/0_installed_packages.R
@@ -1,0 +1,4 @@
+#' @title ip
+#' @description  List all user's packages on load for future reference in functions (since this is an expensive operation)
+#' @importFrom utils installed.packages
+ip <- installed.packages()

--- a/R/makeImport.R
+++ b/R/makeImport.R
@@ -38,13 +38,13 @@
 #' 
 #' @concept populate
 #' @export
-#' @importFrom utils installed.packages capture.output getParseData
+#' @importFrom utils capture.output getParseData
 #' @importFrom tools file_ext
 make_import <- function(script, cut = NULL, print = TRUE, format = "oxygen", desc_loc = NULL) {
   
   on.exit({  if (inherits(script, "function")) unlink(file) },add = TRUE)
   
-  rInst <- paste0(row.names(utils::installed.packages()), "::")
+  rInst <- paste0(row.names(ip), "::")
 
   if (inherits(script, "function")) {
     file <- tempfile()

--- a/R/makeImport.R
+++ b/R/makeImport.R
@@ -44,7 +44,7 @@ make_import <- function(script, cut = NULL, print = TRUE, format = "oxygen", des
   
   on.exit({  if (inherits(script, "function")) unlink(file) },add = TRUE)
   
-  rInst <- paste0(row.names(ip), "::")
+  rInst <- paste0(.packages(all.available = TRUE), "::")
 
   if (inherits(script, "function")) {
     file <- tempfile()

--- a/R/prettify.R
+++ b/R/prettify.R
@@ -5,7 +5,7 @@ prettify <- function(TXT,force = NULL, ignore = NULL, overwrite = FALSE, sos = F
   
   NMPATH <- c(SPATH,setdiff(loadedNamespaces(),SPATH))
   
-  INST <- rownames(ip)
+  INST <- .packages(all.available = TRUE)
   
   DYNPATH <- unlist(sapply(library.dynam(), "[", 2))
   

--- a/R/prettify.R
+++ b/R/prettify.R
@@ -5,7 +5,7 @@ prettify <- function(TXT,force = NULL, ignore = NULL, overwrite = FALSE, sos = F
   
   NMPATH <- c(SPATH,setdiff(loadedNamespaces(),SPATH))
   
-  INST <- rownames(installed.packages())
+  INST <- rownames(ip)
   
   DYNPATH <- unlist(sapply(library.dynam(), "[", 2))
   


### PR DESCRIPTION
Instead of loading installed.packages (computationally expensive) each time the functions that use it run, load it only once when the namespace is loaded and reference that object inside of functions.
This should show significant performance improvements for users that load the namespace via `library` etc but will be the same performance for users that just use namespace prefixes.