### PR TITLE
Fixes issue where a single chunk Rmd has the lines simplified to matrix

### DIFF
--- a/R/pretty_rmd.R
+++ b/R/pretty_rmd.R
@@ -32,11 +32,16 @@ pretty_rmd <- function(input,
                        chunks = NULL,
                        ...){
   
-  x        <- readLines(input,warn = FALSE)
+  xo        <- readLines(input,warn = FALSE)
   
-  x        <- rm_lib_chunk(x)
+  x        <- rm_lib_chunk(xo)
   
   idx      <- list_chunks(x)
+  
+  if (is.null(idx)) {
+    warning("No chunks found - returning as-is.")
+    invisible(xo)
+  }
   
   askenv   <- new.env()
   
@@ -65,6 +70,7 @@ pretty_rmd <- function(input,
 
 list_chunks <- function(x){
   FROM <- grep('^```\\{(.*?)r',x)
+  if (length(FROM) == 0) return(NULL)
   TO <- grep('^```$|^```\\s{1,}$',x)-1
   FROM <- FROM + 1
   ZERO <- FROM > TO

--- a/R/pretty_rmd.R
+++ b/R/pretty_rmd.R
@@ -161,7 +161,7 @@ pretty_rmd_inline <- function(x, idx, askenv,input, chunks,...){
     cat(x[y],file = tf,sep = '\n')
     pretty_namespace(con = tf,...,overwrite = TRUE, askenv = askenv)
     readLines(tf,warn = FALSE)
-  }, idx, names(idx))
+  }, idx, names(idx), SIMPLIFY = FALSE)
   
   for(i in seq_along(idx)){
     x[idx[[i]]] <- y[[i]]


### PR DESCRIPTION
Do not simplify `mapply` output to matrix when just one chunk, otherwise first line of the chunk overwrites all subsequent lines.
This sets `SIMPLIFY = TRUE` to always return a `list`.

Update 2020-11-11T11:40:09

I found an additional bug when an Rmd just has markdown and no chunks. The function throws an obtuse error. 

Handling this exception on this branch since its (kind of) related by detecting no chunks and just returning the document text as is (no changes).