### PR TITLE
Sanity check if no R files exist in `script` directory

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Imports:
     stringi,
     yaml,
     crayon,
-    cli,
+    cli (>= 3.4.1),
     rematch2
 License: MIT + file LICENSE
 Suggests: 

--- a/R/makeImport.R
+++ b/R/makeImport.R
@@ -57,6 +57,9 @@ make_import <- function(script, cut = NULL, print = TRUE, format = "oxygen", des
     } else {
       file <- list.files(script, full.names = TRUE, pattern = "\\.[R|r]$")
     }
+    if (length(file) == 0) {
+      cli::cli_abort("No R files in {.path {script}}, are you sure you selected the right folder?")
+    }
   }
 
   pkg <- sapply(file, function(f) {


### PR DESCRIPTION
Throws informative error when no R files exist in `script` directory