### PR TITLE
Preserve tabs and newlines in imports, remotes, suggests, when using `update_desc`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Version: 0.4.0
 Date: 2022-03-27
 Authors@R: c( person("Jonathan", "Sidi", email = "yonicd@gmail.com", role = c("aut","cre")), person("Anton","Grishin",role
              = "ctb"), person("Lorenzo","Busetto",role = "ctb"), person("Alexey","Shiklomanov",role = "ctb"),
-             person("Stephen","Holsenbeck",role = "ctb"))
+             person("Stephen","Holsenbeck", email = "sholsen@alumni.emory.edu", role = "ctb"))
 Description: Manage package documentation and namespaces from the command line. Programmatically attach namespaces in R and
              Rmd script, populates Roxygen2 skeletons with information scraped from within functions and populate the
              Imports field of the DESCRIPTION file.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,43 +1,39 @@
 Package: sinew
 Type: Package
-Title: Package Development Documentation and Namespace Management 
+Title: Package Development Documentation and Namespace Management
 Version: 0.4.0
 Date: 2022-03-27
-Authors@R: c(
-        person("Jonathan", "Sidi", email = "yonicd@gmail.com", role = c("aut","cre")), 
-        person("Anton","Grishin",role = "ctb"),
-        person("Lorenzo","Busetto",role = "ctb"),
-        person("Alexey","Shiklomanov",role = "ctb"),
-        person("Stephen","Holsenbeck",role = "ctb"))
-Description: Manage package documentation and namespaces from the command line. 
-             Programmatically attach namespaces in R and Rmd script, populates 
-             Roxygen2 skeletons with information scraped from within functions and 
-             populate the Imports field of the DESCRIPTION file.
+Authors@R: c( person("Jonathan", "Sidi", email = "yonicd@gmail.com", role = c("aut","cre")), person("Anton","Grishin",role
+             = "ctb"), person("Lorenzo","Busetto",role = "ctb"), person("Alexey","Shiklomanov",role = "ctb"),
+             person("Stephen","Holsenbeck",role = "ctb"))
+Description: Manage package documentation and namespaces from the command line. Programmatically attach namespaces in R and
+             Rmd script, populates Roxygen2 skeletons with information scraped from within functions and populate the
+             Imports field of the DESCRIPTION file.
 Depends: R (>= 3.2.0)
-Imports: 
-    rstudioapi,
-    utils,
-    tools,
-    sos,
-    stringi,
-    yaml,
-    crayon,
-    cli,
-    rematch2
+Imports: cli,
+	crayon,
+	miniUI,
+	rematch2,
+	rstudioapi,
+	shiny,
+	sos,
+	stringi,
+	tools,
+	utils,
+	yaml
 License: MIT + file LICENSE
-Suggests: 
-    rcmdcheck,
-    git2r,
-    shiny,
-    miniUI,
-    withr,
-    usethis,
-    fs,
-    details,
-    roxygen2,
-    testthat,
-    knitr,
-    rmarkdown
+Suggests: rcmdcheck,
+ git2r,
+ shiny,
+ miniUI,
+ withr,
+ usethis,
+ fs,
+ details,
+ roxygen2,
+ testthat,
+ knitr,
+ rmarkdown
 URL: https://github.com/yonicd/sinew
 BugReports: https://github.com/yonicd/sinew/issues
 LazyData: true

--- a/R/makeImport.R
+++ b/R/makeImport.R
@@ -119,7 +119,7 @@ make_import <- function(script, cut = NULL, print = TRUE, format = "oxygen", des
           desc[, "Imports"] <- gsub("Imports: ", "\n\t", ret)
         }
 
-        write.dcf(desc, file = file.path(desc_loc, "DESCRIPTION"))
+        write.dcf(desc, file = file.path(desc_loc, "DESCRIPTION"), keep.white = c("Imports", "Suggests", "Remotes"))
       }
     }
   }


### PR DESCRIPTION
`update_desc` was flattening imports, remotes, suggests fields in the description because `keep.white` was not used in `read.dcf`. This resolves this bug